### PR TITLE
Add pictor specific MIT license with icon exclusion

### DIFF
--- a/modules/github/license_files/licenses/mit-pictor.txt
+++ b/modules/github/license_files/licenses/mit-pictor.txt
@@ -1,0 +1,26 @@
+Copyright 2023-2026 Code0 UG (haftungsbeschränkt)
+
+This license applies to all files in this repository EXCEPT the contents of the
+directories (and any derived build artifacts) covered by the "Excluded Assets" section
+at the bottom of this file.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Excluded Assets
+
+The contents of the directory "src/components/icon/codezero" (and any build
+artifacts derived from it, such as the corresponding files in the published
+package) are NOT covered by the MIT license above. These files include brand
+logos and trademarks that are the property of their respective owners and are
+used by Code0 UG (haftungsbeschränkt) under permission.
+
+No license or right to use, copy, modify, distribute, sublicense, or otherwise
+exploit these excluded assets is granted to any third party. All rights are
+reserved by their respective owners. Any use of these assets requires the prior
+written permission of the respective rights holder.

--- a/modules/github/license_files/main.tf
+++ b/modules/github/license_files/main.tf
@@ -19,7 +19,7 @@ locals {
     "draco" = "ee"
     "hercules" = "mit"
     "lacerta" = "mit"
-    "pictor" = "mit"
+    "pictor" = "mit-pictor"
     "reticulum" = "ee"
     "sagittarius" = "ee-sagittarius"
     "sculptor" = "ee-sculptor"


### PR DESCRIPTION
@nicosammito asking you for a review here since I used a slightly different wording from your original.